### PR TITLE
Initialize toggle state from props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ const Popover = createClass({
       standing: `above`,
       exited: !this.props.isOpen, // for animation-dependent rendering, should popover close/open?
       exiting: false, // for tracking in-progress animations
-      toggle: false, // for business logic tracking, should popover close/open?
+      toggle: this.props.isOpen, // for business logic tracking, should popover close/open?
     }
   },
   componentDidMount () {


### PR DESCRIPTION
I had an issue with the use case where the popover is open by default - in this case, when I close the popover, it doesn't close because the popover thinks it should toggle to open